### PR TITLE
Remove updated backend from cached external backends

### DIFF
--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -167,7 +167,7 @@ local function sync_backends()
       local backend_with_external_name = util.deepcopy(new_backend)
       backends_with_external_name[backend_with_external_name.name] = backend_with_external_name
     else
-      -- If backends_with_external_name contains this backend, otherwise cached backend will be used.
+      -- If backends_with_external_name contains this backend, remove it, otherwise cached backend will be used.
       if backends_with_external_name[new_backend.name] then
         backends_with_external_name[new_backend.name] = nil
       end

--- a/rootfs/etc/nginx/lua/balancer.lua
+++ b/rootfs/etc/nginx/lua/balancer.lua
@@ -167,6 +167,10 @@ local function sync_backends()
       local backend_with_external_name = util.deepcopy(new_backend)
       backends_with_external_name[backend_with_external_name.name] = backend_with_external_name
     else
+      -- If backends_with_external_name contains this backend, otherwise cached backend will be used.
+      if backends_with_external_name[new_backend.name] then
+        backends_with_external_name[new_backend.name] = nil
+      end
       sync_backend(new_backend)
     end
     balancers_to_keep[new_backend.name] = true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Remove backend from external backends if new backend has the same name, prevents using old cached external backend

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally in Kind cluster using `make dev-env`. Created a namespace `testing`, in the namespace created an NGINX deployment using the official NGINX image, a Service of type `ClusterIP`, and an ingress object that utilizes the Service created. Initially, the Service selects on the pods of the NGINX deployment, the Service is then updated to utilize an external name and that works fine. The Service is updated again to point to NGINX Deployment but the ingress nginx controller still routes to the external service. The Reason is in `balance.lua`, there's a table which is populated with external backends so they're synced independently but when a backend with the same name comes in/synced, it is never removed from `backends_with_external_name`.

This can be fixed by removing the newly fetch backend if it already exists in `backends_with_external_name`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
